### PR TITLE
Fix removing VectorAffine constraint

### DIFF
--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -810,32 +810,19 @@ function MOI.delete(
     deleteblock(m.c_block,cid)
 end
 
-function MOI.delete(
-    m::MosekModel,
-    cref::MOI.ConstraintIndex{F,D}) where {F <: Union{MOI.VectorAffineFunction},
-                                                            D <: Union{MOI.SecondOrderCone,
-                                                                       MOI.RotatedSecondOrderCone,
-                                                                       MOI.ExponentialCone,
-                                                                       MOI.DualExponentialCone,
-                                                                       MOI.PowerCone,
-                                                                       MOI.DualPowerCone}}
+function MOI.delete(m::MosekModel, cref::MOI.ConstraintIndex{F,D}) where {
+    F <: Union{MOI.VectorAffineFunction},
+    D <: Union{MOI.SecondOrderCone, MOI.RotatedSecondOrderCone,
+               MOI.ExponentialCone, MOI.DualExponentialCone,
+               MOI.PowerCone, MOI.DualPowerCone}}
 
     delete!(select(m.constrmap, F, D), cref.value)
     xcid = ref2id(cref)
-    sub = getindexes(m.xc_block,xcid)
 
-    subj = [ getindex(m.x_block,i) for i in sub ]
-    N = length(subj)
-    m.x_boundflags[subj] .&= ~m.xc_bounds[xcid]
-    asgn,coneidx = getconenameindex(m.task,"$(m.xc_coneid[xcid])")
-    m.xc_coneid[xcid] = 0
-    removecone(m.task,coneidx)
+    removecones(m.task, [xcid])
+    removecons(m.task, [xcid])
 
-    m.x_numxc[subj]  -= 1
-    m.xc_idxs[sub]    = 0
-    m.xc_bounds[xcid] = 0
-
-    deleteblock(m.xc_block,xcid)
+    deleteblock(m.c_block, xcid)
 end
 
 


### PR DESCRIPTION
It seems the current implementation was a copy paste from the `VectorOfVariables` code.
@ulfworsoe Does the implementation look good ? I am not sure that it is correct and it correctly deletes things for the Mosek internal representation but it works on simple examples.