### PR TITLE
Remove support for VectorAffineFunction in VectorCone

### DIFF
--- a/src/MosekTools.jl
+++ b/src/MosekTools.jl
@@ -73,8 +73,6 @@ struct ConstraintMap
     axbs_nonnegatives    :: Dict{Int64,Int} # (VectorAffineFunction,Nonnegatives) -> constraint number
     axbs_zeros           :: Dict{Int64,Int} # (VectorAffineFunction,Zeros) -> constraint number
     axbs_reals           :: Dict{Int64,Int} # (VectorAffineFunction,Reals) -> constraint number
-    axbs_qcone           :: Dict{Int64,Int} # (VectorAffineFunction,SecondOrderCone) -> constraint number
-    axbs_rqcone          :: Dict{Int64,Int} # (VectorAffineFunction,RotatedSecondOrderCone) -> constraint number
     axbs_psdconetriangle :: Dict{Int64,Int} # (VectorAffineFunction,PositiveSemidefiniteConeTriangle) -> constraint number
     axbs_ppowcone        :: Dict{Int64,Int} # (VectorOfVariables,RotatedSecondOrderCone) -> constraint number
     axbs_dpowcone        :: Dict{Int64,Int} # (VectorOfVariables,RotatedSecondOrderCone) -> constraint number
@@ -82,7 +80,7 @@ struct ConstraintMap
     axbs_dexpcone        :: Dict{Int64,Int} # (VectorOfVariables,RotatedSecondOrderCone) -> constraint number
 end
 
-ConstraintMap() = ConstraintMap([Dict{Int64,Int}() for i in 1:38]...)
+ConstraintMap() = ConstraintMap([Dict{Int64,Int}() for i in 1:36]...)
 select(cm::ConstraintMap,::Type{MOI.SingleVariable},               ::Type{MOI.LessThan{Float64}}) =                cm.x_lessthan
 select(cm::ConstraintMap,::Type{MOI.SingleVariable},               ::Type{MOI.GreaterThan{Float64}}) =             cm.x_greaterthan
 select(cm::ConstraintMap,::Type{MOI.SingleVariable},               ::Type{MOI.EqualTo{Float64}}) =                 cm.x_equalto
@@ -114,13 +112,7 @@ select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.No
 select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.Nonnegatives}) =                     cm.axbs_nonnegatives
 select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.Zeros}) =                            cm.axbs_zeros
 select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.Reals}) =                            cm.axbs_reals
-select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.SecondOrderCone}) =                  cm.axbs_qcone
-select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.RotatedSecondOrderCone}) =           cm.axbs_rqcone
 select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.PositiveSemidefiniteConeTriangle}) = cm.axbs_psdconetriangle
-select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.PowerCone{Float64}}) =               cm.axbs_ppowcone
-select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.DualPowerCone{Float64}}) =           cm.axbs_dpowcone
-select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.ExponentialCone}) =                  cm.axbs_pexpcone
-select(cm::ConstraintMap,::Type{MOI.VectorAffineFunction{Float64}},::Type{MOI.DualExponentialCone}) =              cm.axbs_dexpcone
 
 Base.getindex(cm::ConstraintMap,r :: MOI.ConstraintIndex{F,D}) where {F,D} = select(cm,F,D)[r.value]
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -97,15 +97,21 @@ function MOI.get(model::MosekModel,
             end
         end
     end
-    for F in [MOI.VectorOfVariables, MOI.VectorAffineFunction{Float64}]
-        for D in [MOI.Nonpositives, MOI.Nonnegatives, MOI.Reals, MOI.Zeros,
-                  MOI.SecondOrderCone, MOI.RotatedSecondOrderCone,
-                  MOI.PowerCone{Float64}, MOI.DualPowerCone{Float64},
-                  MOI.ExponentialCone, MOI.DualExponentialCone,
-                  MOI.PositiveSemidefiniteConeTriangle]
-            if !isempty(select(model.constrmap, F, D))
-                push!(list, (F, D))
-            end
+    F = MOI.VectorOfVariables
+    for D in [MOI.Nonpositives, MOI.Nonnegatives, MOI.Reals, MOI.Zeros,
+              MOI.SecondOrderCone, MOI.RotatedSecondOrderCone,
+              MOI.PowerCone{Float64}, MOI.DualPowerCone{Float64},
+              MOI.ExponentialCone, MOI.DualExponentialCone,
+              MOI.PositiveSemidefiniteConeTriangle]
+        if !isempty(select(model.constrmap, F, D))
+            push!(list, (F, D))
+        end
+    end
+    F = MOI.VectorAffineFunction{Float64}
+    for D in [MOI.Nonpositives, MOI.Nonnegatives, MOI.Reals, MOI.Zeros,
+              MOI.PositiveSemidefiniteConeTriangle]
+        if !isempty(select(model.constrmap, F, D))
+            push!(list, (F, D))
         end
     end
     return list

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -787,35 +787,6 @@ end
 
 function MOI.delete(
     m::MosekModel,
-    cref::MOI.ConstraintIndex{F,D}) where {F <: Union{MOI.VectorAffineFunction},
-                                                            D <: Union{MOI.SecondOrderCone,
-                                                                       MOI.RotatedSecondOrderCone,
-                                                                       MOI.ExponentialCone,
-                                                                       MOI.DualExponentialCone,
-                                                                       MOI.PowerCone,
-                                                                       MOI.DualPowerCone}}
-
-    delete!(select(m.constrmap, F, D), cref.value)
-    xcid = ref2id(cref)
-    sub = getindexes(m.xc_block,xcid)
-
-    subj = [ getindex(m.x_block,i) for i in sub ]
-    N = length(subj)
-    m.x_boundflags[subj] .&= ~m.xc_bounds[xcid]
-    asgn,coneidx = getconenameindex(m.task,"$(m.xc_coneid[xcid])")
-    m.xc_coneid[xcid] = 0
-    removecone(m.task,coneidx)
-
-    m.x_numxc[subj]  -= 1
-    m.xc_idxs[sub]    = 0
-    m.xc_bounds[xcid] = 0
-
-    deleteblock(m.xc_block,xcid)
-end
-
-
-function MOI.delete(
-    m::MosekModel,
     cref::MOI.ConstraintIndex{F,D}) where {F <: Union{MOI.SingleVariable,
                                                       MOI.VectorOfVariables},
                                            D <: Union{ScalarLinearDomain,


### PR DESCRIPTION
If I am not mistaken, it was handled by creating slack variables in the cone and setting the affine expression equal to these variables, which is exactly what is now done by the slack bridge:
https://github.com/JuliaOpt/MathOptInterface.jl/pull/610
All the tricky book-keeping is handled by the bridges, it would simplify this package if we don't do any transformation and only support constraints that are natively supported. For instance, it would be nice to be able to remove
https://github.com/JuliaOpt/MosekTools.jl/blob/bf20b84b7e3da4d879d2a0fd1f77c5f0102eb86e/src/MosekTools.jl#L173
because not slack variable are created.
Currently we still need to for the PSD constraints tough, see https://github.com/JuliaOpt/MosekTools.jl/issues/11