### PR TITLE
Refactor variable.jl

### DIFF
--- a/src/MosekTools.jl
+++ b/src/MosekTools.jl
@@ -486,11 +486,6 @@ ref2id(ref :: MOI.ConstraintIndex) :: Int =
         - Int(ref.value >> 1)
     end
 
-function id2vref(id :: Int) :: MOI.VariableIndex
-    @assert(id > 0)
-    MOI.VariableIndex(id)
-end
-
 include("objective.jl")
 include("variable.jl")
 include("constraint.jl")

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -80,8 +80,6 @@ MOI.get(m::MosekModel,attr::MOI.ResultCount) = length(m.solutions)
 
 #### Problem information
 
-MOI.get(m::MosekModel,attr::MOI.NumberOfVariables) = m.publicnumvar
-
 function MOI.get(m::MosekModel, ::MOI.NumberOfConstraints{F,D}) where {F,D}
     return length(select(m.constrmap, F, D))
 end
@@ -153,12 +151,6 @@ function MOI.set(m::MosekModel,attr::MOI.VariablePrimalStart, vs::Vector{MOI.Var
     end
 end
 
-
-function MOI.set(m::MosekModel, attr::MOI.VariableName,
-                 index :: MOI.VariableIndex, value :: String)
-    subj = getindex(m.x_block, ref2id(index))
-    putvarname(m.task, subj, value)
-end
 
 # function MOI.set(m::MosekModel,attr::MOI.ConstraintDualStart, vs::Vector{MOI.ConstraintIndex}, vals::Vector{Float64})
 #     subj = Array{Int}(length(vs))

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -4,6 +4,9 @@
 # matrix while the MOI variables numbering can have holes, i.e. when variables
 # are deleted.
 
+###############################################################################
+## ADD
+
 """
     function allocate_variable(m::MosekModel)
 
@@ -170,4 +173,18 @@ function MOI.delete(m::MosekModel, ref::MOI.VariableIndex)
     clear_columns(m, [ref])
 
     clear_variable(m, ref)
+end
+
+###############################################################################
+## ATTRIBUTES
+
+MOI.get(m::MosekModel, attr::MOI.NumberOfVariables) = m.publicnumvar
+function MOI.get(m::MosekModel, attr::MOI.ListOfVariableIndices)
+    ids = allocatedlist(m.x_block)
+    return MOI.VariableIndex[MOI.VariableIndex(vid) for vid in ids]
+end
+
+function MOI.set(m::MosekModel, ::MOI.VariableName, ref::MOI.VariableIndex,
+                 value::String)
+    putvarname(m.task, column(m, ref), value)
 end


### PR DESCRIPTION
Refactor to share common code into documented function. Try to keep `MOI.VariableIndex` as much as possible to keep a kind of type-safety since with `Int`s it's easy to misuse the `Int` as the index of something else.
Also implement `ListOfVariableIndices`.