### PR TITLE
Temporarily remove REDUCTION_CERTIFICATE

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -491,7 +491,7 @@ function MOI.get(m::MosekModel, attr::MOI.PrimalStatus)
     elseif solsta == MSK_SOL_STA_PRIM_ILLPOSED_CER
         MOI.NO_SOLUTION
     elseif solsta == MSK_SOL_STA_DUAL_ILLPOSED_CER
-        MOI.REDUCTION_CERTIFICATE
+        MOI.UNKNOWN_RESULT_STATUS
     elseif solsta == MSK_SOL_STA_INTEGER_OPTIMAL
         MOI.FEASIBLE_POINT
     else
@@ -516,7 +516,7 @@ function MOI.get(m::MosekModel,attr::MOI.DualStatus)
     elseif solsta == MSK_SOL_STA_DUAL_INFEAS_CER
         MOI.NO_SOLUTION
     elseif solsta == MSK_SOL_STA_PRIM_ILLPOSED_CER
-        MOI.REDUCTION_CERTIFICATE
+        MOI.UNKNOWN_RESULT_STATUS
     elseif solsta == MSK_SOL_STA_DUAL_ILLPOSED_CER
         MOI.NO_SOLUTION
     elseif solsta == MSK_SOL_STA_INTEGER_OPTIMAL


### PR DESCRIPTION
It is not defined in MOI v0.8, see https://github.com/JuliaOpt/MathOptInterface.jl/issues/725