### PR TITLE
Remove deprecated termination codes (Mosek v9)

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -459,10 +459,6 @@ function MOI.get(m::MosekModel, attr::MOI.TerminationStatus)
         MOI.TIME_LIMIT
     elseif m.trm == MSK_RES_TRM_OBJECTIVE_RANGE
         MOI.OBJECTIVE_LIMIT
-    elseif m.trm == MSK_RES_TRM_MIO_NEAR_REL_GAP
-        MOI.ALMOST_OPTIMAL
-    elseif m.trm == MSK_RES_TRM_MIO_NEAR_ABS_GAP
-        MOI.ALMOST_OPTIMAL
     elseif m.trm == MSK_RES_TRM_MIO_NUM_RELAXS
         MOI.OTHER_LIMIT
     elseif m.trm == MSK_RES_TRM_MIO_NUM_BRANCHES


### PR DESCRIPTION
`MSK_RES_TRM_MIO_NEAR_REL_GAP` and `MSK_RES_TRM_MIO_NEAR_ABS_GAP` are deprecated in Mosek v9, and are not defined in Mosek#master.
This results in an error when calling `JuMP.value()`, since the termination status is checked.