### PR TITLE
Remove VOV constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ git:
   depth: 99999999
 before-install:
   - sudo apt-get install curl
+before_script:
+  - julia -e 'using Pkg; Pkg.add(PackageSpec(name="JuMP", rev="master"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,3 @@ git:
   depth: 99999999
 before-install:
   - sudo apt-get install curl
-before_script:
-  - julia -e 'using Pkg; Pkg.add(PackageSpec(name="JuMP", rev="master"))'

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Mosek = "6405355b-0ac2-5fba-af84-adbd65488c0e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-MathOptInterface = "0.9"
+MathOptInterface = "0.9.2"
 Mosek = "1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Mosek = "6405355b-0ac2-5fba-af84-adbd65488c0e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-MathOptInterface = "0.9.2"
+MathOptInterface = "0.9.4"
 Mosek = "1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Mosek = "6405355b-0ac2-5fba-af84-adbd65488c0e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-MathOptInterface = "0.9.4"
+MathOptInterface = "0.9.5"
 Mosek = "1"
 julia = "1"
 

--- a/src/MosekTools.jl
+++ b/src/MosekTools.jl
@@ -112,6 +112,10 @@ mutable struct MosekModel  <: MOI.AbstractOptimizer
     """
     c_block :: LinkedInts
 
+    # Needed when the vector of variables is deleted as the constraint need
+    # to be deleted as well.
+    vector_of_variables_to_constraint::Dict{Vector{MOI.VariableIndex}, MOI.ConstraintIndex{MOI.VectorOfVariables}}
+
     ###########################
     trm :: Union{Nothing, Rescode}
     solutions :: Vector{MosekSolution}
@@ -257,6 +261,7 @@ function Mosek.Optimizer(; kws...)
                        MatrixIndex[], # x_sd
                        Int[], # sd_dim
                        LinkedInts(), # c_block
+                       Dict{Vector{MOI.VariableIndex}, MOI.ConstraintIndex{MOI.VectorOfVariables}}(),
                        nothing,# trm
                        MosekSolution[],
                        true, # feasibility_sense
@@ -368,16 +373,17 @@ function MOI.empty!(model::MosekModel)
     end
     model.publicnumvar       = 0
     model.has_variable_names = false
-    model.constrnames        = Dict{String, Vector{MOI.ConstraintIndex}}()
-    model.con_to_name        = Dict{MOI.ConstraintIndex, String}()
-    model.x_type             = VariableType[]
-    model.x_constraints      = UInt8[]
+    empty!(model.constrnames)
+    empty!(model.con_to_name)
+    empty!(model.x_type)
+    empty!(model.x_constraints)
     model.x_block            = LinkedInts()
-    model.x_sd               = MatrixIndex[]
-    model.sd_dim             = Int[]
+    empty!(model.x_sd)
+    empty!(model.sd_dim)
     model.c_block            = LinkedInts()
+    empty!(mosek.vector_of_variables_to_constraint)
     model.trm                = nothing
-    model.solutions          = MosekSolution[]
+    empty!(model.solutions)
     model.feasibility        = true
 end
 

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -410,7 +410,9 @@ function MOI.add_constraint(m::MosekModel, xs::MOI.VectorOfVariables,
     N = MOI.dimension(dom)
     id = add_cone(m, cols, dom)
 
-    return MOI.ConstraintIndex{MOI.VectorOfVariables, D}(id)
+    ci = MOI.ConstraintIndex{MOI.VectorOfVariables, D}(id)
+    m.vector_of_variables_to_constraint[xs.variables] = ci
+    return ci
 end
 
 ################################################################################

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -270,7 +270,7 @@ function row(m::MosekModel,
     return getindex(m.c_block, c.value)
 end
 function columns(m::MosekModel, ci::MOI.ConstraintIndex{MOI.VectorOfVariables})
-    return ColumnIndices(getcone(m.task, ci.value)[4])
+    return ColumnIndices(getcone(m.task, cone_id(m, ci))[4])
 end
 
 const VectorCone = Union{MOI.SecondOrderCone,
@@ -409,10 +409,17 @@ function MOI.add_constraint(m::MosekModel, xs::MOI.VectorOfVariables,
 
     N = MOI.dimension(dom)
     id = add_cone(m, cols, dom)
+    idx = first(xs.variables).value
+    for vi in xs.variables
+        m.variable_to_vector_constraint_id[vi.value] = -idx
+    end
+    m.variable_to_vector_constraint_id[idx] = id
 
-    ci = MOI.ConstraintIndex{MOI.VectorOfVariables, D}(id)
-    m.vector_of_variables_to_constraint[xs.variables] = ci
+    ci = MOI.ConstraintIndex{MOI.VectorOfVariables, D}(idx)
     return ci
+end
+function cone_id(model::MosekModel, ci::MOI.ConstraintIndex{MOI.VectorOfVariables})
+    return model.variable_to_vector_constraint_id[ci.value]
 end
 
 ################################################################################
@@ -518,9 +525,43 @@ function MOI.get(m::MosekModel, ::MOI.ConstraintFunction,
     return MOI.ScalarAffineFunction(terms, 0.0)
 end
 function MOI.get(m::MosekModel, ::MOI.ConstraintSet,
-                 ci::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},
-                                         S}) where S
+                 ci::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}})
     return get_bound(m, ci)
+end
+
+function MOI.get(m::MosekModel, ::MOI.ConstraintFunction,
+                 ci::MOI.ConstraintIndex{MOI.VectorOfVariables, S}) where S <: VectorCone
+    return MOI.VectorOfVariables([
+        index_of_column(m, col) for col in reorder(columns(m, ci).values, S)
+    ])
+end
+function type_cone(ct)
+    if ct == MSK_CT_PEXP
+        return MOI.ExponentialCone
+    elseif ct == MSK_CT_DEXP
+        return MOI.DualExponentialCone
+    elseif ct == MSK_CT_PPOW
+        return MOI.PowerCone{Float64}
+    elseif ct == MSK_CT_DPOW
+        return MOI.DualPowerCone{Float64}
+    elseif ct == MSK_CT_QUAD
+        return MOI.SecondOrderCone
+    elseif ct == MSK_CT_RQUAD
+        return MOI.RotatedSecondOrderCone
+    else
+        error("Unrecognized Mosek cone type `$ct`.")
+    end
+end
+cone(::Type{MOI.ExponentialCone}, conepar, nummem) = MOI.ExponentialCone()
+cone(::Type{MOI.DualExponentialCone}, conepar, nummem) = MOI.DualExponentialCone()
+cone(::Type{MOI.PowerCone{Float64}}, conepar, nummem) = MOI.PowerCone(conepar)
+cone(::Type{MOI.DualPowerCone{Float64}}, conepar, nummem) = MOI.DualPowerCone(conepar)
+cone(::Type{MOI.SecondOrderCone}, conepar, nummem) = MOI.SecondOrderCone(nummem)
+cone(::Type{MOI.RotatedSecondOrderCone}, conepar, nummem) = MOI.RotatedSecondOrderCone(nummem)
+function MOI.get(m::MosekModel, ::MOI.ConstraintSet,
+                 ci::MOI.ConstraintIndex{MOI.VectorOfVariables, <:VectorCone})
+    ct, conepar, nummem = getconeinfo(m.task, cone_id(m, ci))
+    return cone(type_cone(ct), conepar, nummem)
 end
 
 ## Modify #####################################################################
@@ -534,9 +575,8 @@ chgbound(bl::Float64,bu::Float64,k::Float64,dom :: MOI.Interval{Float64})    = d
 
 function MOI.set(m::MosekModel,
                  ::MOI.ConstraintSet,
-                 ci::MOI.ConstraintIndex{F,D},
-                 dom::D) where {F<:MOI.SingleVariable,
-                                D<:ScalarLinearDomain}
+                 ci::MOI.ConstraintIndex{MOI.SingleVariable,D},
+                 dom::D) where D<:ScalarLinearDomain
     col = column(m, _variable(ci))
     bk, bl, bu = getvarbound(m.task, col.value)
     bl, bu = chgbound(bl, bu, 0.0, dom)
@@ -546,14 +586,13 @@ end
 
 function MOI.set(m::MosekModel,
                  ::MOI.ConstraintSet,
-                 cref::MOI.ConstraintIndex{F,D},
-                 dom::D) where { F    <: MOI.ScalarAffineFunction,
-                                 D    <: ScalarLinearDomain }
+                 cref::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction,D},
+                 dom::D) where D <: ScalarLinearDomain
     cid = ref2id(cref)
-    i = getindex(m.c_block,cid) # since we are in a scalar domain
-    bk, bl, bu = getconbound(m.task,i)
-    bl, bu = chgbound(bl,bu,0.0,dom)
-    putconbound(m.task,i,bk,bl,bu)
+    i = getindex(m.c_block, cid) # since we are in a scalar domain
+    bk, bl, bu = getconbound(m.task, i)
+    bl, bu = chgbound(bl, bu, 0.0, dom)
+    putconbound(m.task, i, bk, bl, bu)
 end
 
 
@@ -643,8 +682,24 @@ end
 function MOI.is_valid(model::MosekModel,
                       ci::MOI.ConstraintIndex{MOI.VectorOfVariables,
                                               S}) where S<:VectorCone
-    return 1 ≤ ci.value ≤ getnumcone(model.task) &&
-        getconeinfo(model.task, ci.value)[1] == cone_type(S)
+    if !(ci.value in eachindex(model.variable_to_vector_constraint_id))
+        return false
+    end
+    id = cone_id(model, ci)
+    return 1 ≤ id ≤ getnumcone(model.task) &&
+        getconeinfo(model.task, id)[1] == cone_type(S)
+end
+function MOI.delete(model::MosekModel,
+                    ci::MOI.ConstraintIndex{MOI.VectorOfVariables, <:VectorCone})
+    id = cone_id(model, ci)
+    for vi in MOI.get(model, MOI.ConstraintFunction(), ci).variables
+        model.variable_to_vector_constraint_id[vi.value] = 0
+    end
+    removecones(model.task, [id])
+    # The conic constraints with id higher than `id` are renumbered.
+    map!(i -> i > id ? i - 1 : i,
+         model.variable_to_vector_constraint_id,
+         model.variable_to_vector_constraint_id)
 end
 function MOI.is_valid(model::MosekModel,
                       ci::MOI.ConstraintIndex{MOI.VectorOfVariables,

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -240,21 +240,31 @@ end
 function MOI.is_valid(model::MosekModel, vi::MOI.VariableIndex)
     return allocated(model.x_block, ref2id(vi))
 end
-
-#function MOI.delete(m::MosekModel, vis::Vector{MOI.VariableIndex})
-#    for vi in vis
-#        throw_if_cannot_delete(m, vi)
-#    end
+function delete_vector_of_variables_constraint(m::MosekModel, vis::Vector{MOI.VariableIndex})
+    ci = get(m.vector_of_variables_to_constraint, vis, nothing)
+    if ci != nothing
+        MOI.delete(m, ci)
+    end
+end
+function MOI.delete(m::MosekModel, vis::Vector{MOI.VariableIndex})
+    for vi in vis
+        throw_if_cannot_delete(m, vi)
+    end
+    delete_vector_of_variables_constraint(m, vis)
+    for vi in vis
+        MOI.delete(m, vi)
+    end
 #    clear_columns(m, vis)
 #    for vi in vis
 #        clear_variable(m, vi)
 #    end
-#end
+end
 function MOI.delete(m::MosekModel, vi::MOI.VariableIndex)
     if variable_type(m, vi) == Undecided
         m.publicnumvar -= 1
     else
         throw_if_cannot_delete(m, vi)
+        delete_vector_of_variables_constraint(m, [vi])
         clear_columns(m, [vi])
         clear_variable(m, vi)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,10 +90,11 @@ const config = MOIT.TestConfig(atol=1e-3, rtol=1e-3)
     @testset "Conic" begin
         MOIT.basic_constraint_tests(
             optimizer, config,
-            delete = false, # TODO
-            get_constraint_function = false, # TODO
-            get_constraint_set = false, # TODO
             include=[
+                (MOI.VectorOfVariables, MOI.ExponentialCone),
+                (MOI.VectorOfVariables, MOI.DualExponentialCone),
+                (MOI.VectorOfVariables, MOI.PowerCone{Float64}),
+                (MOI.VectorOfVariables, MOI.DualPowerCone{Float64}),
                 (MOI.VectorOfVariables, MOI.SecondOrderCone),
                 (MOI.VectorOfVariables, MOI.RotatedSecondOrderCone)
         ])
@@ -115,6 +116,8 @@ end
 @testset "Unit" begin
     # Mosek does not support names
     MOIT.unittest(bridged, config, [
+        # TODO
+        "number_threads",
         # Find objective bound of 0.0 which is lower than 4.0
         "solve_objbound_edge_cases",
         # Cannot put multiple bound sets of the same type on a variable
@@ -130,7 +133,12 @@ end
 end
 
 @testset "Continuous Quadratic" begin
-    MOIT.contquadratictest(bridged, config, ["ncqcp"])
+    MOIT.contquadratictest(bridged, config, [
+        # Non-convex
+        "ncqcp",
+        # QuadtoSOC does not work as the matrix is not SDP
+        "socp"
+    ])
 end
 
 @testset "Continuous Conic" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,9 +115,6 @@ end
 @testset "Unit" begin
     # Mosek does not support names
     MOIT.unittest(bridged, config, [
-        # Does not support quadratic objective yet, needs
-        # https://github.com/JuliaOpt/MathOptInterface.jl/issues/529
-        "solve_qp_edge_cases",
         # Find objective bound of 0.0 which is lower than 4.0
         "solve_objbound_edge_cases",
         # Cannot put multiple bound sets of the same type on a variable
@@ -133,7 +130,7 @@ end
 end
 
 @testset "Continuous Quadratic" begin
-    MOIT.qcptest(bridged, config)
+    MOIT.contquadratictest(bridged, config, ["ncqcp"])
 end
 
 @testset "Continuous Conic" begin


### PR DESCRIPTION
This is needed for passes QP tests.

- [x] Use `removecones`. /!\ That will reorder indices so we might change our indexing of VoV constraints.
- [x] Wait for MOI v0.9.5
- [x] Require MOI v0.9.5 in Project.toml

Requires https://github.com/JuliaOpt/MathOptInterface.jl/pull/917
Requires https://github.com/JuliaOpt/MathOptInterface.jl/pull/916